### PR TITLE
Allow the creation without Attributes

### DIFF
--- a/src/Hangfire.MissionControl/MissionControlBootstrapperExtensions.cs
+++ b/src/Hangfire.MissionControl/MissionControlBootstrapperExtensions.cs
@@ -1,31 +1,59 @@
 ﻿global using Hangfire.Annotations;
 global using System;
 global using System.Linq;
-using System.Reflection;
 using Hangfire.Dashboard;
 using Hangfire.MissionControl.Dashboard.Content;
 using Hangfire.MissionControl.Dashboard.Pages;
 using Hangfire.MissionControl.Launching;
 using Hangfire.MissionControl.Mapping;
+using Hangfire.MissionControl.Model;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace Hangfire.MissionControl;
 
 public static class MissionControlBootstrapperExtensions
 {
+    private static readonly MissionControlOptions _defaultOptions = new() { RequireConfirmation = true };
+
     [PublicAPI]
     public static IGlobalConfiguration UseMissionControl(
         this IGlobalConfiguration configuration,
         params Assembly[] missionAssemblies)
-        => configuration.UseMissionControl(new MissionControlOptions { RequireConfirmation = true }, missionAssemblies);
+        => configuration.UseMissionControl(_defaultOptions, missionAssemblies);
 
     [PublicAPI]
     public static IGlobalConfiguration UseMissionControl(
         this IGlobalConfiguration configuration,
         MissionControlOptions options,
         params Assembly[] missionAssemblies)
-    {
-        var map = MissionMapBuilder.BuildMap(missionAssemblies);
+     => configuration.UseMissionControl(options, MissionMapBuilder.BuildMap(missionAssemblies));
 
+    [PublicAPI]
+    public static IGlobalConfiguration UseMissionControl(
+        this IGlobalConfiguration configuration,
+        IDictionary<string, Mission> missions)
+        => configuration.UseMissionControl(_defaultOptions, missions);
+
+    [PublicAPI]
+    public static IGlobalConfiguration UseMissionControl(
+        this IGlobalConfiguration configuration,
+        MissionControlOptions options,
+        IDictionary<string, Mission> missions)
+        => configuration.UseMissionControl(options, new MissionMap(missions));
+
+    [PublicAPI]
+    public static IGlobalConfiguration UseMissionControl(
+        this IGlobalConfiguration configuration,
+        MissionMap map)
+        => configuration.UseMissionControl(_defaultOptions, map);
+
+    [PublicAPI]
+    public static IGlobalConfiguration UseMissionControl(
+        this IGlobalConfiguration configuration,
+        MissionControlOptions options,
+        MissionMap map)
+    {
         DashboardRoutes.Routes.AddRazorPage("/missions",
             x => new MissionsOverviewPage(map.MissionCategories.FirstOrDefault().Key ?? "default", map, options));
         DashboardRoutes.Routes.AddRazorPage("/missions/(?<categoryId>.+)",

--- a/src/Hangfire.MissionControl/Model/Mission.cs
+++ b/src/Hangfire.MissionControl/Model/Mission.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Hangfire.MissionControl.Model;
 
-internal sealed class Mission
+public sealed class Mission
 {
     public const string IdField = "id";
     public string Id { get; }
@@ -15,12 +15,32 @@ internal sealed class Mission
     public MethodInfo MethodInfo { get; }
 
     public Mission(MissionLauncherAttribute launcherAttribute, MissionAttribute missionAttribute, MethodInfo methodInfo)
+        : this(
+             methodInfo,
+             missionAttribute.Name ?? methodInfo.Name,
+             launcherAttribute.CategoryName ?? methodInfo.DeclaringType?.Name ?? "Default",
+             missionAttribute.Queue,
+             missionAttribute.Description)
+    {
+    }
+
+    public Mission(Delegate function, string name, string categoryName = "Default", string queue = "default", string description = "")
+        : this(
+             function.GetMethodInfo(),
+             name,
+             categoryName,
+             queue,
+             description)
+    {
+    }
+
+    public Mission(MethodInfo methodInfo, string? name = null, string categoryName = "Default", string queue = "default", string description = "")
     {
         Id = GenerateId(methodInfo);
-        CategoryName = launcherAttribute.CategoryName ?? methodInfo.DeclaringType?.Name ?? "Default";
-        Name = missionAttribute.Name ?? methodInfo.Name;
-        Queue = missionAttribute.Queue ?? "default";
-        Description = missionAttribute.Description;
+        CategoryName = categoryName;
+        Name = name ?? methodInfo.Name;
+        Queue = queue;
+        Description = description;
         MethodInfo = methodInfo;
     }
 

--- a/src/Hangfire.MissionControl/Model/MissionMap.cs
+++ b/src/Hangfire.MissionControl/Model/MissionMap.cs
@@ -2,14 +2,15 @@
 
 namespace Hangfire.MissionControl.Model;
 
-internal class MissionMap
+public class MissionMap
 {
-    public Dictionary<string, int> MissionCategories { get; }
-    public Dictionary<string, Mission> Missions { get; }
+    public IDictionary<string, int> MissionCategories { get; }
+    public IDictionary<string, Mission> Missions { get; }
 
-    public MissionMap(Dictionary<string, Mission> missions)
+    public MissionMap(IDictionary<string, Mission> missions)
     {
-        Missions = missions.OrderBy(x => x.Value.Name)
+        Missions = missions
+            .OrderBy(x => x.Value.Name)
             .ToDictionary(x => x.Key, x => x.Value);
 
         MissionCategories = missions.Values


### PR DESCRIPTION
This PR makes the `Mission` and `MissionMap` classes public so a user can create them manually without the need to use `Attribute`s.
It also adds overloads in `MissionControlBootstrapperExtensions` which allows for an easy usage of the functionality without `Attribute`s.