### PR TITLE
Move to Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Hangfire.AspNetCore" Version="1.7.34" />
+    <PackageVersion Include="Hangfire.Core" Version="[1.7.34, 1.8]" />
+    <PackageVersion Include="Hangfire.MemoryStorage" Version="1.7.0" />
+    <PackageVersion Include="RazorGenerator.MsBuild" Version="2.5.0" />
+    <PackageVersion Include="RazorGenerator.Templating" Version="2.4.7" />
+  </ItemGroup>
+</Project>

--- a/src/Hangfire.MissionControl/Hangfire.MissionControl.csproj
+++ b/src/Hangfire.MissionControl/Hangfire.MissionControl.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <RazorSrcFiles Include="Dashboard\Pages\*.cshtml" />
+	<RazorSrcFiles Remove="Dashboard\Pages\MissionsOverviewPage.cshtml" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -33,10 +34,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <RazorSrcFiles Remove="Dashboard\Pages\MissionsOverviewPage.cshtml" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="Dashboard\Content\bootstrap-datetimepicker.min.css" />
     <EmbeddedResource Include="Dashboard\Content\bootstrap-datetimepicker.min.js" />
     <EmbeddedResource Include="Dashboard\Content\missions.css" />
@@ -45,13 +42,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="[1.7.3, 1.8]" />
-    <PackageReference Include="RazorGenerator.MsBuild" Version="2.4.7">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="RazorGenerator.Templating" Version="2.4.7">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Hangfire.Core" />
+    <PackageReference Include="RazorGenerator.MsBuild" PrivateAssets="all" />
+    <PackageReference Include="RazorGenerator.Templating" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/tests/Hangfire.MissionControl.Tests.Web/Hangfire - Backup.MissionControl.Tests.Web.csproj
+++ b/tests/Hangfire.MissionControl.Tests.Web/Hangfire - Backup.MissionControl.Tests.Web.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" />
     <PackageReference Include="Hangfire.MemoryStorage" />
   </ItemGroup>


### PR DESCRIPTION
- Moved over to using Central Package Management
- The test project did not need the full Hangire package - just Hangfire.AspNetCore (which is where Hangfire.Dashboard is located)